### PR TITLE
feat: initial spike for sync with foreground service

### DIFF
--- a/app/App_Resources/Android/src/main/AndroidManifest.xml
+++ b/app/App_Resources/Android/src/main/AndroidManifest.xml
@@ -36,5 +36,9 @@
 			</intent-filter>
 		</activity>
 		<activity android:name="com.tns.ErrorReportActivity"/>
+		<service
+			android:name="com.tns.ForegroundService"
+			android:enabled="true"
+			android:exported="true"></service>
 	</application>
 </manifest>

--- a/platforms/android/app/build.gradle
+++ b/platforms/android/app/build.gradle
@@ -471,7 +471,7 @@ tasks.whenTaskAdded({ org.gradle.api.DefaultTask currentTask ->
         extractAllJars.finalizedBy(collectAllJars)
     }
     if (currentTask =~ /compile.+JavaWithJavac/) {
-        currentTask.dependsOn(runSbg)
+        //currentTask.dependsOn(runSbg)
         currentTask.finalizedBy(buildMetadata)
     }
     if (currentTask =~ /merge.*Assets/) {

--- a/platforms/android/app/src/debug/java/com/tns/ForegroundService.java
+++ b/platforms/android/app/src/debug/java/com/tns/ForegroundService.java
@@ -1,0 +1,131 @@
+package com.tns;
+
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.app.PendingIntent;
+import android.app.Service;
+import android.content.Intent;
+import android.os.Build;
+import android.os.IBinder;
+import android.os.Binder;
+import androidx.annotation.Nullable;
+import androidx.core.app.NotificationCompat;
+import android.os.Handler;
+import android.os.Message;
+import android.os.Messenger;
+import android.os.RemoteException;
+
+public class ForegroundService extends Service {
+    /**
+     * Command to the service to register a client, receiving callbacks
+     * from the service.  The Message's replyTo field must be a Messenger of
+     * the client where callbacks should be sent.
+     */
+    static final int MSG_REGISTER_CLIENT = 1;
+
+    /**
+     * Command to the service to unregister a client, ot stop receiving callbacks
+     * from the service.  The Message's replyTo field must be a Messenger of
+     * the client as previously given with MSG_REGISTER_CLIENT.
+     */
+    static final int MSG_UNREGISTER_CLIENT = 2;
+
+    /**
+     * Command to service to set a new value.  This can be sent to the
+     * service to supply a new value, and will be sent by the service to
+     * any registered clients with the new value.
+     */
+    static final int MSG_SET_VALUE = 3;
+    public static final String CHANNEL_ID = "ForegroundServiceChannel";
+    private Messenger mClient = null;
+    private  NativeScriptSyncServiceSocketImpl syncService = null;
+
+
+
+    Handler threadHandler = new Handler(new Handler.Callback() {
+        @Override
+        public boolean handleMessage(Message msg) {
+            try {
+                mClient.send(Message.obtain(null,
+                        MSG_SET_VALUE));
+            } catch (RemoteException e) {
+            }
+
+            return true;
+        }
+    });
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+    }
+
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        String input = intent.getStringExtra("inputExtra");
+        createNotificationChannel();
+        Intent notificationIntent = new Intent(this, NativeScriptActivity.class);
+        PendingIntent pendingIntent = PendingIntent.getActivity(this,
+                0, notificationIntent, 0);
+
+        Notification notification = new NotificationCompat.Builder(this, CHANNEL_ID)
+                .setContentTitle("Foreground Service")
+                .setContentText(input)
+                .setContentIntent(pendingIntent)
+                .build();
+
+        startForeground(1, notification);
+
+        if(this.syncService == null) {
+            this.syncService = new com.tns.NativeScriptSyncServiceSocketImpl(null, new LogcatLogger(this), this, threadHandler);
+            syncService.startServer();
+        }
+
+        return START_STICKY;
+    }
+
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+    }
+
+    @Override
+    public IBinder onBind(Intent intent) {
+        return mMessenger.getBinder();
+    }
+
+    private void createNotificationChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            NotificationChannel serviceChannel = new NotificationChannel(
+                    CHANNEL_ID,
+                    "Foreground Service Channel",
+                    NotificationManager.IMPORTANCE_DEFAULT
+            );
+
+            NotificationManager manager = getSystemService(NotificationManager.class);
+            manager.createNotificationChannel(serviceChannel);
+        }
+    }
+
+    /**
+     * Handler of incoming messages from clients.
+     */
+    class IncomingHandler extends Handler {
+        @Override
+        public void handleMessage(Message msg) {
+            switch (msg.what) {
+                case MSG_REGISTER_CLIENT:
+                    mClient = msg.replyTo;
+                    break;
+                default:
+                    super.handleMessage(msg);
+            }
+        }
+    }
+
+    /**
+     * Target we publish for clients to send messages to IncomingHandler.
+     */
+    final Messenger mMessenger = new Messenger(new IncomingHandler());
+}

--- a/platforms/android/app/src/main/java/com/tns/RuntimeHelper.java
+++ b/platforms/android/app/src/main/java/com/tns/RuntimeHelper.java
@@ -197,9 +197,9 @@ public final class RuntimeHelper {
 
                     // if app is in debuggable mode run livesync service
                     // runtime needs to be initialized before the NativeScriptSyncService is enabled because it uses runtime.runScript(...)
-                    initLiveSync(runtime, logger, context);
+                    //(runtime, logger, context);
 
-                    waitForLiveSync(context);
+                    //waitForLiveSync(context);
                 }
 
                 runtime.runScript(new File(appDir, "internal/ts_helpers.js"));


### PR DESCRIPTION
The main idea is to start the foreground service in CLI before the first sync using adb:
```
adb shell am start-foreground-service org.nativescript.backgroundSync/com.tns.ForegroundService
```

We should also add a button to kill the service from the notification and also kill it from adb when the CLI command is terminated:
```
adb shell am force-stop org.nativescript.backgroundSync
```